### PR TITLE
Fix: review patch

### DIFF
--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -631,7 +631,7 @@ export const DataType: DataTypeDTO = {
       ],
     },
     PATCH: {
-      '/review\n내가 참여한 방탈출 리뷰수정': [
+      '/review/{reviewId}\n내가 참여한 방탈출 리뷰수정': [
         {
           label: 'Headers',
           content: {
@@ -642,7 +642,8 @@ export const DataType: DataTypeDTO = {
         {
           label: 'Request Body',
           content: {
-            image: 'file',
+            content: 'string',
+            images: 'file[]',
             numberOfPlayer: 'number',
             success: 'boolean',
             hint: 'number',
@@ -650,7 +651,6 @@ export const DataType: DataTypeDTO = {
             themeReview: 'string',
             levelReview: 'string',
             storyReview: 'string',
-            reviewComment: 'string',
           },
         },
       ],


### PR DESCRIPTION
review patch 시 uri에서 review id를 받도록 수정
리뷰에 이미지를 여러 개 넣을 수 있어 patch에도 여러 개를 받도록 수정