### PR TITLE
Fix: api 경로 수정 및 정리

### DIFF
--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -754,7 +754,7 @@ export const DataType: DataTypeDTO = {
           },
         },
       ],
-      '/host/{hostName}\n호스트의 다른 모임 조회': [
+      '/gathering/host/{hostName}\n호스트의 다른 모임 조회': [
         {
           label: 'Headers',
           content: {
@@ -794,7 +794,7 @@ export const DataType: DataTypeDTO = {
           },
         },
       ],
-      '/date\n같은 날짜 다른 모임 조회': [
+      '/gathering/date\n같은 날짜 다른 모임 조회': [
         {
           label: 'Headers',
           content: {

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -116,7 +116,7 @@ export const DataType: DataTypeDTO = {
           },
         },
       ],
-      '/user/schedule\n나의 일정': [
+      '/user/me/schedule\n나의 일정': [
         {
           label: 'Headers',
           content: {
@@ -359,31 +359,6 @@ export const DataType: DataTypeDTO = {
                 },
               ],
             },
-          },
-        },
-      ],
-    },
-    POST: {
-      '/user/me/theme\n내가 참여한 방탈출 리뷰쓰기': [
-        {
-          label: 'Headers',
-          content: {
-            ContentType: 'multipart/form-data',
-            Authorization: 'Bearer {accessToken}',
-          },
-        },
-        {
-          label: 'Request Body',
-          content: {
-            image: 'file',
-            numberOfPlayer: 'number',
-            success: 'boolean',
-            hint: 'number',
-            myRating: 'number',
-            themeReview: 'string',
-            levelReview: 'string',
-            storyReview: 'string',
-            reviewComment: 'string',
           },
         },
       ],

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -492,6 +492,8 @@ export const DataType: DataTypeDTO = {
             keyword: 'string',
             city: 'string',
             state: 'string',
+            limit: 'number',
+            offset: 'number',
           },
         },
         {

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -798,6 +798,12 @@ export const DataType: DataTypeDTO = {
           },
         },
         {
+          label: 'Parameters',
+          content: {
+            gatheringId: 'number',
+          },
+        },
+        {
           label: 'Responses',
           content: {
             totalCount: 'number',
@@ -829,6 +835,12 @@ export const DataType: DataTypeDTO = {
           content: {
             ContentType: 'application/json',
             Authorization: 'Bearer {accessToken}',
+          },
+        },
+        {
+          label: 'Parameters',
+          content: {
+            gatheringId: 'number',
           },
         },
         {

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -939,7 +939,7 @@ export const DataType: DataTypeDTO = {
   },
   GatheringMember: {
     GET: {
-      '/gathering/member\n모임 참가자 목록 조회': [
+      '/gathering/{gatheringId}/member\n모임 참가자 목록 조회': [
         {
           label: 'Headers',
           content: {
@@ -962,7 +962,7 @@ export const DataType: DataTypeDTO = {
       ],
     },
     POST: {
-      '/gathering/member\n모임 참여': [
+      '/gathering/{gatheringId}/member\n모임 참여': [
         {
           label: 'Headers',
           content: {
@@ -973,7 +973,7 @@ export const DataType: DataTypeDTO = {
       ],
     },
     DELETE: {
-      '/gathering/member\n모임 참여 취소': [
+      '/gathering/{gatheringId}/member\n모임 참여 취소': [
         {
           label: 'Headers',
           content: {

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -364,7 +364,7 @@ export const DataType: DataTypeDTO = {
       ],
     },
     PATCH: {
-      '/user/me\n내 프로필 수정': [
+      '/user/me\n내 프로필 및 이미지 수정': [
         {
           label: 'Headers',
           content: {
@@ -376,6 +376,24 @@ export const DataType: DataTypeDTO = {
           label: 'Request Body',
           content: {
             image: 'file',
+            nickname: 'string',
+            comment: 'string',
+            emailMark: 'boolean',
+            genderMark: 'boolean',
+          },
+        },
+      ],
+      '/user/me\n내 프로필 수정': [
+        {
+          label: 'Headers',
+          content: {
+            ContentType: 'application/json',
+            Authorization: 'Bearer {accessToken}',
+          },
+        },
+        {
+          label: 'Request Body',
+          content: {
             nickname: 'string',
             comment: 'string',
             emailMark: 'boolean',

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -789,6 +789,40 @@ export const DataType: DataTypeDTO = {
           },
         },
       ],
+      '/host/{hostName}\n호스트의 다른 모임 조회': [
+        {
+          label: 'Headers',
+          content: {
+            ContentType: 'application/json',
+            Authorization: 'Bearer {accessToken}',
+          },
+        },
+        {
+          label: 'Responses',
+          content: {
+            totalCount: 'number',
+            currentPage: 'number',
+            data: [
+              {
+                gatheringId: 'number',
+                name: 'string',
+                listImage: 'string',
+                genres: 'string[]',
+                playtime: 'number',
+                themeId: 'number',
+                cafe: 'string',
+                spot: 'string',
+                dateTime: 'string',
+                registrationEnd: 'string',
+                capacity: 'number',
+                participantCount: 'number',
+                address: 'string',
+                level: 'string',
+              },
+            ],
+          },
+        },
+      ],
       '/gathering/{gatheringId}\n모임 상세 조회': [
         {
           label: 'Headers',

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -823,6 +823,40 @@ export const DataType: DataTypeDTO = {
           },
         },
       ],
+      '/date\n같은 날짜 다른 모임 조회': [
+        {
+          label: 'Headers',
+          content: {
+            ContentType: 'application/json',
+            Authorization: 'Bearer {accessToken}',
+          },
+        },
+        {
+          label: 'Responses',
+          content: {
+            totalCount: 'number',
+            currentPage: 'number',
+            data: [
+              {
+                gatheringId: 'number',
+                name: 'string',
+                listImage: 'string',
+                genres: 'string[]',
+                playtime: 'number',
+                themeId: 'number',
+                cafe: 'string',
+                spot: 'string',
+                dateTime: 'string',
+                registrationEnd: 'string',
+                capacity: 'number',
+                participantCount: 'number',
+                address: 'string',
+                level: 'string',
+              },
+            ],
+          },
+        },
+      ],
       '/gathering/{gatheringId}\n모임 상세 조회': [
         {
           label: 'Headers',

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -458,12 +458,6 @@ export const DataType: DataTypeDTO = {
           },
         },
         {
-          label: 'Parameters',
-          content: {
-            themeId: 'number',
-          },
-        },
-        {
           label: 'Responses',
           content: {
             themeId: 'number',
@@ -509,12 +503,6 @@ export const DataType: DataTypeDTO = {
             Authorization: 'Bearer {accessToken}',
           },
         },
-        {
-          label: 'Parameters',
-          content: {
-            themeId: 'number',
-          },
-        },
       ],
       '/theme/{themeId}/visit\n방탈출 참여': [
         {
@@ -522,12 +510,6 @@ export const DataType: DataTypeDTO = {
           content: {
             ContentType: 'application/json',
             Authorization: 'Bearer {accessToken}',
-          },
-        },
-        {
-          label: 'Parameters',
-          content: {
-            themeId: 'number',
           },
         },
       ],
@@ -541,12 +523,6 @@ export const DataType: DataTypeDTO = {
             Authorization: 'Bearer {accessToken}',
           },
         },
-        {
-          label: 'Parameters',
-          content: {
-            themeId: 'number',
-          },
-        },
       ],
       '/theme/{themeId}/visit\n방탈출 참여 해제': [
         {
@@ -554,12 +530,6 @@ export const DataType: DataTypeDTO = {
           content: {
             ContentType: 'application/json',
             Authorization: 'Bearer {accessToken}',
-          },
-        },
-        {
-          label: 'Parameters',
-          content: {
-            themeId: 'number',
           },
         },
       ],
@@ -872,12 +842,6 @@ export const DataType: DataTypeDTO = {
           },
         },
         {
-          label: 'Parameters',
-          content: {
-            gatheringId: 'number',
-          },
-        },
-        {
           label: 'Responses',
           content: {
             gatheringId: 'number',
@@ -926,12 +890,6 @@ export const DataType: DataTypeDTO = {
             Authorization: 'Bearer {accessToken}',
           },
         },
-        {
-          label: 'Parameters',
-          content: {
-            gatheringId: 'number',
-          },
-        },
       ],
     },
     PATCH: {
@@ -967,12 +925,6 @@ export const DataType: DataTypeDTO = {
             Authorization: 'Bearer {accessToken}',
           },
         },
-        {
-          label: 'Parameters',
-          content: {
-            gatheringId: 'number',
-          },
-        },
       ],
       '/gathering/{gatheringId}/like\n모임 찜 삭제': [
         {
@@ -980,12 +932,6 @@ export const DataType: DataTypeDTO = {
           content: {
             ContentType: 'application/json',
             Authorization: 'Bearer {accessToken}',
-          },
-        },
-        {
-          label: 'Parameters',
-          content: {
-            gatheringId: 'number',
           },
         },
       ],
@@ -998,12 +944,6 @@ export const DataType: DataTypeDTO = {
           label: 'Headers',
           content: {
             ContentType: 'application/json',
-          },
-        },
-        {
-          label: 'Parameters',
-          content: {
-            gatheringId: 'number',
           },
         },
         {
@@ -1030,12 +970,6 @@ export const DataType: DataTypeDTO = {
             Authorization: 'Bearer {accessToken}',
           },
         },
-        {
-          label: 'Parameters',
-          content: {
-            gatheringId: 'number',
-          },
-        },
       ],
     },
     DELETE: {
@@ -1045,12 +979,6 @@ export const DataType: DataTypeDTO = {
           content: {
             ContentType: 'application/json',
             Authorization: 'Bearer {accessToken}',
-          },
-        },
-        {
-          label: 'Parameters',
-          content: {
-            gatheringId: 'number',
           },
         },
       ],
@@ -1136,7 +1064,6 @@ export const DataType: DataTypeDTO = {
           label: 'Parameters',
           content: {
             gatheringId: 'number',
-            commentId: 'number',
           },
         },
         {
@@ -1160,7 +1087,6 @@ export const DataType: DataTypeDTO = {
           label: 'Parameters',
           content: {
             gatheringId: 'number',
-            commentId: 'number',
           },
         },
       ],


### PR DESCRIPTION
- host의 다른 모임 조회 추가
- 같은 날짜 다른 모임 조회 추가
- 방탈출 검색 시 limit offset 추가
- POST /user/me/theme는 review로 옮겨졌으므로 삭제
- /user/me/schedule로 경로 수정
- 유저 정보 업데이트 시 이미지 있는 api와 없는 api로 분리
- 일부 api 경로에 있는 변수값이 parameter로 들어가있어 삭제
- /gathering/member/{gatheringId}는 의미가 이상해지기에 /gathering/{gatheringId}/member로 수정